### PR TITLE
Optimize

### DIFF
--- a/gaga_phsp/gaga.py
+++ b/gaga_phsp/gaga.py
@@ -350,6 +350,8 @@ class Gan(object):
             self.x,
             batch_size=batch_size,
             num_workers=2,  # no gain if larger than 2 (?)
+            # https://discuss.pytorch.org/t/data-loader-multiprocessing-slow-on-macos/131204/3
+            persistent_workers=True,
             pin_memory=True,
             # https://discuss.pytorch.org/t/what-is-the-disadvantage-of-using-pin-memory/1702/4
             shuffle=self.params["shuffle"],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("readme.md", "r") as fh:
 
 setuptools.setup(
     name="gaga-phsp",
-    version="0.6.0",
+    version="0.7.0",
     author="David Sarrut",
     author_email="david.sarrut@creatis.insa-lyon.fr",
     description="Python tools for GATE GAN simulations",
@@ -24,10 +24,10 @@ setuptools.setup(
         "colorama",
         "click",
         "scipy",
-        "garf",
+        "garf>=2.4",
         "matplotlib",
         "gatetools",
-        # 'torch'   # better to install torch manually to match cuda version
+        # 'torch'   # the installation of torch is managed by garf
     ],
     scripts=[
         "bin/gaga_train",


### PR DESCRIPTION
Same problem than here:
https://discuss.pytorch.org/t/data-loader-multiprocessing-slow-on-macos/131204/3

I added persistent_workers=True
I did not want to add multiprocessing_context="forkserver" to avoid potential problem with fork on windows

Still a little bit longer on mac at the beginning because the workers take more time to initialize